### PR TITLE
added the project field and the related pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ storage/*
 !web.config
 app/config/config.local.neon
 app/database.test
+
+composer.lock
+composer.phar

--- a/app/ApiModule/presenters/ExperimentsPresenter.php
+++ b/app/ApiModule/presenters/ExperimentsPresenter.php
@@ -17,17 +17,19 @@ class ExperimentsPresenter extends BasePresenter {
 		$description = $this->getPostParameter( 'description' );
 		$source = $this->getPostFile( 'source' );
 		$reference = $this->getPostFile( 'reference' );
+		$project = $this->getPostParameter( 'project' );
 
 		$data = array(
 			'name' => $name,
 			'description' => $description,
+			'project' => $project,
 			'url_key' => $url_key
 		);
 
 		$path = __DIR__ . '/../../../data/' . $url_key . '/';
 		$source->move( $path . 'source.txt' );
 		$reference->move( $path . 'reference.txt' );
-		file_put_contents( $path . 'config.neon', "name: $name\ndescription: $description\nurl_key: $url_key" );
+		file_put_contents( $path . 'config.neon', "name: $name\ndescription: $description\nproject: $project\nurl_key: $url_key" );
 
 		$response = array( 'experiment_id' => $this->model->saveExperiment( $data ) );
 

--- a/app/model/Experiments.php
+++ b/app/model/Experiments.php
@@ -29,6 +29,23 @@ class Experiments {
 			->fetch();
 	}
 
+	public function getProjects() {
+		$experiments = $this->getExperiments();
+		$projects = array();
+		foreach ($experiments as $experiment) {
+			if (!in_array($experiment['project'], $projects)) {
+				array_push($projects, $experiment['project']);
+			}
+		}
+		sort($projects);
+		return $projects;
+	}
+
+	public function getExperimentsByProject( $project ) {
+		return $this->db->table( 'experiments' )
+			->where( 'project', $project );
+	}
+
 	public function saveExperiment( $data ) {
 		if ( !$row = $this->getExperimentByName( $data[ 'url_key' ] ) ) {
 			$row = $this->db->table( 'experiments' )->insert( $data );
@@ -37,11 +54,10 @@ class Experiments {
 		return $row->getPrimary( TRUE );
 	}
 
-	public function updateExperiment( $experimentId, $name, $description ) {
+	public function updateExperiment( $experimentId, $name, $description, $project ) {
 		$this->db->table( 'experiments' )
 			->get( $experimentId )
-			->update( array( 'name' => $name, 'description' => $description ) );
-
+			->update( array( 'name' => $name, 'description' => $description, 'project' => $project ) );
 	}
 
 	public function setVisible( $experimentId ) {

--- a/app/presenters/ExperimentsPresenter.php
+++ b/app/presenters/ExperimentsPresenter.php
@@ -18,6 +18,20 @@ class ExperimentsPresenter extends BasePresenter {
 		$this->template->experiments = $this->experimentsModel->getExperiments();
 	}
 
+	public function renderListperproj() {
+		$this->template->experiments = $this->experimentsModel->getExperiments();
+		$this->template->projects = $this->experimentsModel->getProjects();
+	}
+
+	public function renderListforproj( $name ) {
+		$this->template->project = $name;
+		$this->template->experiments = $this->experimentsModel->getExperimentsByProject($name);
+	}
+
+	public function renderProjects() {
+		$this->template->projects = $this->experimentsModel->getProjects();
+	}
+
 	public function renderDownload() {
 		$output = fopen( "php://output", "w" ) or die( "Can't open php://output" );
 		header( "Content-Type:application/csv" );
@@ -66,8 +80,9 @@ class ExperimentsPresenter extends BasePresenter {
 		$id = $data[ 'id' ];
 		$name = $data[ 'name' ];
 		$description = $data[ 'description' ];
+		$project = $data[ 'project' ];
 
-		$this->experimentsModel->updateExperiment( $id, $name, $description );
+		$this->experimentsModel->updateExperiment( $id, $name, $description, $project );
 
 		$this->flashMessage( 'Experiment was successfully updated.', 'alert-success' );
 		$this->redirect( 'list' );
@@ -85,6 +100,7 @@ class ExperimentsPresenter extends BasePresenter {
 			->addRule( Form::FILLED, 'Please, fill in a name of the experiment.' );
 		$form->addTextArea( 'description', 'Description' )
 			->addRule( Form::FILLED, 'Please, fill in a description of the experiment.' );
+		$form->addText( 'project', 'Project' );
 		$form->addHidden( 'id' );
 		$form->addSubmit('save', 'Save');
 		$form->onSubmit[] = array( $this, 'saveEditForm' );
@@ -102,6 +118,7 @@ class ExperimentsPresenter extends BasePresenter {
 		$renderer->wrappers[ 'control' ][ 'container' ] = 'div class=controls';
 		$renderer->wrappers[ 'label' ][ 'container' ] = 'div class=control-label';
 		$renderer->wrappers[ 'control' ][ 'description' ] = 'span class=help-inline';
+		$renderer->wrappers[ 'control' ][ 'project' ] = 'span class=help-inline';
 		$renderer->wrappers[ 'control' ][ 'errorcontainer' ] = 'span class=help-inline';
 		$form->getElementPrototype()->class( 'form-horizontal' );
 

--- a/app/router/RouterFactory.php
+++ b/app/router/RouterFactory.php
@@ -45,7 +45,11 @@ class RouterFactory
 			$router[] = new Route('api/ngrams/unconfirmed', 'Api:NGrams:unconfirmed');
 			$router[] = new Route('tasks/<id1>-<id2>/compare', 'Tasks:compare');
 			$router[] = new Route('tasks/<id>/detail', 'Tasks:detail');
+			$router[] = new Route('api/projects', 'Experiments:projects');
+			$router[] = new Route('api/projects/experiments', 'Experiments:listperproj');
+			$router[] = new Route('api/projects/<name>', 'Experiments:listforproj');
 			$router[] = new Route('<presenter>/<action>[/<id>]', 'Experiments:list');
+
 		}
 
 		return $router;

--- a/app/templates/Experiments/list.latte
+++ b/app/templates/Experiments/list.latte
@@ -3,10 +3,17 @@
 
 {if count($experiments)}
 <table class="table table-bordered">
+<tr>
+	<th>Name</th>
+	<th>Description</th>
+	<th>Project</th>
+	<th>Actions</th>
+</tr>
 {foreach $experiments->order( 'name' ) as $experiment}
 	<tr class="experiment" data-id="{$experiment['url_key']}">
 		<td class="name span3"><a href="{plink Tasks:list $experiment['id']}">{$experiment['name']}</a></td>
 		<td class="description">{$experiment['description']}</td>
+		<td class="project">{$experiment['project']}</td>
 		{if $showAdministration}
 		<td class="span2">
 			<div class="text-right">
@@ -29,3 +36,6 @@
 {/if}
 
 <a href="{plink Experiments:download}" class="btn btn-default">Download statistics</a>
+
+<div style="margin-top:30px;"><a href="/api/projects">List of all projects</a></div>
+<div><a href="/api/projects/experiments">List of all experiments per project</a></div>

--- a/app/templates/Experiments/listforproj.latte
+++ b/app/templates/Experiments/listforproj.latte
@@ -1,0 +1,42 @@
+{block #content}
+<h1>Experiments of the project {$project}</h1>
+
+{if count($experiments)}
+	<table class="table table-bordered">
+	<tr>
+		<th>Name</th>
+		<th>Description</th>
+		<th>Project</th>
+		<th>Actions</th>
+	</tr>
+
+	{foreach $experiments->order( 'name' ) as $experiment}
+		<tr class="experiment" data-id="{$experiment['url_key']}">
+			<td class="name span3"><a href="{plink Tasks:list $experiment['id']}">{$experiment['name']}</a></td>
+			<td class="description">{$experiment['description']}</td>
+			<td class="project">{$experiment['project']}</td>
+			{if $showAdministration}
+			<td class="span2">
+				<div class="text-right">
+					<a href="{plink Experiments:edit $experiment['id']}">edit</a>
+					<a href="{plink Experiments:delete $experiment['id']}" onclick="return confirm('Do you really want to delete this? There is no way to undo this action')">delete</a>
+				</div>
+			</td>
+			{/if}
+		</tr>
+	{/foreach}
+
+	</table>
+{else}
+	<div class="alert">
+		There are no experiments.
+	</div>
+{/if}
+
+{if $showAdministration}
+	<a href="{plink Experiments:new}" class="btn btn-default">New Experiment</a>
+{/if}
+
+<div style="margin-top:30px;"><a href="/api/projects">List of all projects</a></div>
+<div><a href="/">List of all experiments</a></div>
+<div><a href="/api/projects/experiments">List of all experiments per project</a></div>

--- a/app/templates/Experiments/listperproj.latte
+++ b/app/templates/Experiments/listperproj.latte
@@ -1,0 +1,48 @@
+{block #content}
+<h1>Experiments per project</h1>
+
+{if count($experiments)}
+	{foreach $projects as $project}
+		<h2><a href="/api/projects/{$project}">{$project}</a></h2>
+		<table class="table table-bordered">
+		<tr>
+			<th>Name</th>
+			<th>Description</th>
+			<th>Project</th>
+			<th>Actions</th>
+		</tr>
+
+		{foreach $experiments->order( 'name' ) as $experiment}
+			{if $experiment['project'] == $project}
+				<tr class="experiment" data-id="{$experiment['url_key']}">
+					<td class="name span3"><a href="{plink Tasks:list $experiment['id']}">{$experiment['name']}</a></td>
+					<td class="description">{$experiment['description']}</td>
+					<td class="project">{$experiment['project']}</td>
+					{if $showAdministration}
+					<td class="span2">
+						<div class="text-right">
+							<a href="{plink Experiments:edit $experiment['id']}">edit</a>
+							<a href="{plink Experiments:delete $experiment['id']}" onclick="return confirm('Do you really want to delete this? There is no way to undo this action')">delete</a>
+						</div>
+					</td>
+					{/if}
+				</tr>
+			{/if}
+		{/foreach}
+
+	</table>
+	{/foreach}
+{else}
+	<div class="alert">
+		There are no experiments.
+	</div>
+{/if}
+
+{if $showAdministration}
+	<a href="{plink Experiments:new}" class="btn btn-default">New Experiment</a>
+{/if}
+
+<a href="{plink Experiments:download}" class="btn btn-default">Download statistics</a>
+
+<div style="margin-top:30px;"><a href="/api/projects">List of all projects</a></div>
+<div><a href="/">List of all experiments</a></div>

--- a/app/templates/Experiments/new.latte
+++ b/app/templates/Experiments/new.latte
@@ -15,6 +15,12 @@
 		</div>
 	</div>
 	<div class="control-group">
+		<label class="control-label" for="project">Project</label>
+		<div class="controls">
+			<input type="text" id="project" name="project" class="input-block-level">
+		</div>
+	</div>
+	<div class="control-group">
 		<label class="control-label" for="source">Source</label>
 		<div class="controls">
 			<input type="file" id="source" name="source" class="input-block-level">

--- a/app/templates/Experiments/projects.latte
+++ b/app/templates/Experiments/projects.latte
@@ -1,0 +1,22 @@
+{block #content}
+<h1>Projects</h1>
+
+{if count($projects)}
+	{foreach $projects as $project}
+		<h2><a href="/api/projects/{$project}">{$project}</a></h2>
+	{/foreach}
+	<div style="margin-bottom:20px;"></div>
+{else}
+	<div class="alert">
+		There are no projects.
+	</div>
+{/if}
+
+{if $showAdministration}
+	<a href="{plink Experiments:new}" class="btn btn-default">New Experiment</a>
+{/if}
+
+<a href="{plink Experiments:download}" class="btn btn-default">Download statistics</a>
+
+<div style="margin-top:30px;"><a href="/">List of all experiments</a></div>
+<div><a href="/api/projects/experiments">List of all experiments per project</a></div>

--- a/schema.sql
+++ b/schema.sql
@@ -3,6 +3,7 @@ CREATE TABLE "experiments" (
   "name" text NOT NULL,
   "url_key" text NOT NULL UNIQUE,
   "description" text NOT NULL,
+  "project" text DEFAULT NULL,
   "visible" integer(0) NULL
 );
 


### PR DESCRIPTION
Before these changes, experiments were only presented as a long list of all the experiments

- Added a field "Project" when adding an experiment
- Created a new page showing all projects
- Created a new page grouping the expriments by project
- Created a new page showing all experiments for the selected project
- Updated the existing experiment list with a project column